### PR TITLE
PRC-56 - add support for topology in PARConnector

### DIFF
--- a/par-connector/src/main/r/R/PA.r
+++ b/par-connector/src/main/r/R/PA.r
@@ -271,6 +271,8 @@ error = function(e) {print(str_c("Error when replacing pattern ", pattern, " in 
 #'  @param ip.selection can be used to restrict the remote execution to a given machine given its IP address
 #'  @param property.selection.name can be used to restrict the remote execution to a given JVM resource where the property is set to the according value
 #'  @param property.selection.value is used in combination with property.selection.name
+#'  @param nodes.number the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.
+#'  @param topology a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.
 #'  @param generic.information.list a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)
 #'  @param run.as.me a boolean value which, if set to TRUE, make the ProActive Task run under this user account (impersonation), and not under the account of the ProActive Scheduler
 #'  @param client connection handle to the scheduler, if not provided the handle created by the last call to PAConnect will be used
@@ -297,7 +299,7 @@ error = function(e) {print(str_c("Error when replacing pattern ", pattern, " in 
 #'  
 #'  }
 #'  @seealso  \code{\link{PA}} \code{\link{PAS}}  \code{\link{PASolve}} \code{\link{mapply}} \code{\link{PAConnect}} 
-PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE, client = PAClient(), .debug = PADebug()) {
+PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, nodes.number = 1, topology = "SINGLE_HOST", generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE, client = PAClient(), .debug = PADebug()) {
   dots <- list(...)
   
   # if we are merging find all list of tasks in parameters, construct new function call
@@ -336,6 +338,8 @@ PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.f
   newcall[["ip.selection"]] <- ip.selection
   newcall[["property.selection.name"]] <- property.selection.name
   newcall[["property.selection.value"]] <- property.selection.value
+  newcall[["nodes.number"]] <- nodes.number
+  newcall[["topology"]] <- topology
   newcall[["generic.information.list"]] <- generic.information.list
   newcall[["run.as.me"]] <- run.as.me
   newcall[["isolate.io.files"]] <- isolate.io.files
@@ -360,6 +364,8 @@ PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.f
           ip.selection = ip.selection,
           property.selection.name=property.selection.name,
           property.selection.value = property.selection.value,
+          nodes.number = nodes.number,
+          topology = topology,
           generic.information.list = generic.information.list,
           run.as.me = run.as.me,
           isolate.io.files = isolate.io.files,
@@ -412,6 +418,8 @@ PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.f
 #'  @param ip.selection can be used to restrict the remote execution to a given machine given its IP address
 #'  @param property.selection.name can be used to restrict the remote execution to a given JVM resource where the property is set to the according value
 #'  @param property.selection.value is used in combination with property.selection.name
+#'  @param nodes.number the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.
+#'  @param topology a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.
 #'  @param generic.information.list a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)
 #'  @param run.as.me a boolean value which, if set to TRUE, make the ProActive Task run under this user account (impersonation), and not under the account of the ProActive Scheduler
 #'  @param client connection handle to the scheduler, if not provided the handle created by the last call to PAConnect will be used
@@ -435,12 +443,12 @@ PAM <- function(funcOrFuncName, ..., varies=list(), input.files=list(), output.f
 #'
 #'  }       
 #'  @seealso  \code{\link{PA}} \code{\link{PAM}}  \code{\link{PASolve}} \code{\link{mapply}} \code{\link{PAJobResult}} \code{\link{PAConnect}} 
-PAS <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE, client = PAClient(), .debug = PADebug()) {
+PAS <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, nodes.number = 1, topology = "SINGLE_HOST", generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE, client = PAClient(), .debug = PADebug()) {
   
   dots <- list(...)
    
   # we generate a task with a forced cardinality of 1
-  task <- PA(funcOrFuncName, ..., varies=list(),input.files=input.files, output.files=output.files, in.dir = in.dir, out.dir = out.dir, hostname.selection = hostname.selection, ip.selection = ip.selection, property.selection.name = property.selection.name, property.selection.value = property.selection.value, generic.information.list = generic.information.list, run.as.me = run.as.me, isolate.io.files = isolate.io.files, client = client, .debug = .debug)
+  task <- PA(funcOrFuncName, ..., varies=list(),input.files=input.files, output.files=output.files, in.dir = in.dir, out.dir = out.dir, hostname.selection = hostname.selection, ip.selection = ip.selection, property.selection.name = property.selection.name, property.selection.value = property.selection.value, nodes.number = nodes.number, topology = topology, generic.information.list = generic.information.list, run.as.me = run.as.me, isolate.io.files = isolate.io.files, client = client, .debug = .debug)
   if (length(task) > 1) {
     stop(paste0("Internal Error : Unexpected task list length, expected 1, received ",length(task)))
   }
@@ -549,6 +557,8 @@ PAS <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.fil
 #'  @param ip.selection can be used to restrict the remote execution to a given machine given its IP address
 #'  @param property.selection.name can be used to restrict the remote execution to a given JVM resource where the property is set to the according value
 #'  @param property.selection.value is used in combination with property.selection.name
+#'  @param nodes.number the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.
+#'  @param topology a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.
 #'  @param generic.information.list a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)
 #'  @param run.as.me a boolean value which, if set to TRUE, make the ProActive Task run under this user account (impersonation), and not under the account of the ProActive Scheduler
 #'  @param isolate.io.files should input/output files be isolated in the remote executions, default FALSE.
@@ -578,7 +588,7 @@ PAS <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.fil
 #'  
 #'  }
 #'  @seealso  \code{\link{PAS}} \code{\link{PAM}}  \code{\link{PASolve}} \code{\link{mapply}} \code{\link{PAJobResult}} \code{\link{PAConnect}} 
-PA <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE,  client = PAClient(), .debug = PADebug()) {
+PA <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.files=list(), in.dir = getwd(), out.dir = getwd(), hostname.selection = NULL, ip.selection = NULL, property.selection.name = NULL, property.selection.value = NULL, nodes.number = 1, topology = "SINGLE_HOST", generic.information.list = NULL, run.as.me = FALSE, isolate.io.files = FALSE,  client = PAClient(), .debug = PADebug()) {
   if (is.character(funcOrFuncName)) {
     fun <- match.fun(funcOrFuncName)
     funname <- funcOrFuncName
@@ -826,6 +836,12 @@ PA <- function(funcOrFuncName, ..., varies=NULL, input.files=list(), output.file
     }
 
     jtsk <- getJavaObject(t)
+    
+    if (nodes.number > 1) {
+      td <- .jfield(J("org.ow2.proactive.topology.descriptor.TopologyDescriptor"), topology)
+      jtsk$setParallelEnvironment(.jnew(J("org.ow2.proactive.scheduler.common.task.ParallelEnvironment"),nodes.number,td))
+    }
+    
     if (!is.null(generic.information.list)) {
       for (j in names(generic.information.list)) {
         jtsk$addGenericInformation(j, generic.information.list[[j]])

--- a/par-connector/src/main/r/man/PA.Rd
+++ b/par-connector/src/main/r/man/PA.Rd
@@ -8,6 +8,7 @@ PA(funcOrFuncName, ..., varies = NULL, input.files = list(),
   output.files = list(), in.dir = getwd(), out.dir = getwd(),
   hostname.selection = NULL, ip.selection = NULL,
   property.selection.name = NULL, property.selection.value = NULL,
+  nodes.number = 1, topology = "SINGLE_HOST",
   generic.information.list = NULL, run.as.me = FALSE,
   isolate.io.files = FALSE, client = PAClient(), .debug = PADebug())
 }
@@ -33,6 +34,10 @@ PA(funcOrFuncName, ..., varies = NULL, input.files = list(),
 \item{property.selection.name}{can be used to restrict the remote execution to a given JVM resource where the property is set to the according value}
 
 \item{property.selection.value}{is used in combination with property.selection.name}
+
+\item{nodes.number}{the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.}
+
+\item{topology}{a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.}
 
 \item{generic.information.list}{a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)}
 

--- a/par-connector/src/main/r/man/PAM.Rd
+++ b/par-connector/src/main/r/man/PAM.Rd
@@ -8,6 +8,7 @@ PAM(funcOrFuncName, ..., varies = list(), input.files = list(),
   output.files = list(), in.dir = getwd(), out.dir = getwd(),
   hostname.selection = NULL, ip.selection = NULL,
   property.selection.name = NULL, property.selection.value = NULL,
+  nodes.number = 1, topology = "SINGLE_HOST",
   generic.information.list = NULL, run.as.me = FALSE,
   isolate.io.files = FALSE, client = PAClient(), .debug = PADebug())
 }
@@ -33,6 +34,10 @@ PAM(funcOrFuncName, ..., varies = list(), input.files = list(),
 \item{property.selection.name}{can be used to restrict the remote execution to a given JVM resource where the property is set to the according value}
 
 \item{property.selection.value}{is used in combination with property.selection.name}
+
+\item{nodes.number}{the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.}
+
+\item{topology}{a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.}
 
 \item{generic.information.list}{a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)}
 

--- a/par-connector/src/main/r/man/PAS.Rd
+++ b/par-connector/src/main/r/man/PAS.Rd
@@ -8,6 +8,7 @@ PAS(funcOrFuncName, ..., varies = NULL, input.files = list(),
   output.files = list(), in.dir = getwd(), out.dir = getwd(),
   hostname.selection = NULL, ip.selection = NULL,
   property.selection.name = NULL, property.selection.value = NULL,
+  nodes.number = 1, topology = "SINGLE_HOST",
   generic.information.list = NULL, run.as.me = FALSE,
   isolate.io.files = FALSE, client = PAClient(), .debug = PADebug())
 }
@@ -33,6 +34,10 @@ PAS(funcOrFuncName, ..., varies = NULL, input.files = list(),
 \item{property.selection.name}{can be used to restrict the remote execution to a given JVM resource where the property is set to the according value}
 
 \item{property.selection.value}{is used in combination with property.selection.name}
+
+\item{nodes.number}{the number of ProActive Nodes needed, on the same machine, to execute this R task (in case this task runs multiple threads in parallel, and there are multiple ProActive Nodes per machine). Default to 1.}
+
+\item{topology}{a character string containing the ProActive topology associated with the number of nodes. The topology determines how multiple nodes will be selected. Default to "SINGLE_HOST", which means that all nodes will be selected from the same host. Refer to ProActive documentation to understand possible values.}
 
 \item{generic.information.list}{a list containing generic informations to be added to the ProActive Task (example list(INFO1 = "true"), adds the generic info INFO1 = "true" to the task)}
 


### PR DESCRIPTION
now the user can specify the number of nodes and the topology in PA calls.