### PR TITLE
Close and recreate JRI engine after each script eval with forked tasks

### DIFF
--- a/par-script/src/main/java/org/ow2/parscript/PARScriptFactory.java
+++ b/par-script/src/main/java/org/ow2/parscript/PARScriptFactory.java
@@ -113,4 +113,5 @@ public final class PARScriptFactory implements ScriptEngineFactory {
         }
         return ret.toString();
     }
+
 }


### PR DESCRIPTION
When a task is forked (created in a new processus), the forker is waiting for
the termination of the task. Since the JRI engine was created but not closed
once the script evaluation has completed, the task was hanging.

The idea of this patch is to close and recreate a JRI engine instance for
each script evaluation when forked tasks are used. If tasks are not forked, then
the same behaviour as before is applied: JRI engine instance is cached for
avoiding an expensive load operation when the context is big (lot of variables,
large script, etc.)

This patch fixes #70.