### PR TITLE
In some configurations, setting R current directory to user home dir is not permitted

### DIFF
--- a/pa-jri/src/main/java/org/ow2/pajri/PAJRIEngine.java
+++ b/pa-jri/src/main/java/org/ow2/pajri/PAJRIEngine.java
@@ -29,6 +29,8 @@ import java.util.Map;
  */
 public class PAJRIEngine extends PAREngine implements REngineCallbacks, REngineOutputInterface {
 
+    private static String tmpDir = System.getProperty("java.io.tmpdir");
+
 
     private static PAJRIEngine instance;
     /**
@@ -147,7 +149,7 @@ public class PAJRIEngine extends PAREngine implements REngineCallbacks, REngineO
             this.lastErrorMessage = null;
 
             // Fix for PRC-30: Always change working dir to avoid keeping a file handle on task temp dir
-            engine.engineEval("setwd(Sys.getenv(\"HOME\"))", ctx);
+            engine.engineEval("setwd(\"" + toRpath(tmpDir) + "\")", ctx);
             if (isInForkedTask()) {
                 engine.end();
             }


### PR DESCRIPTION
found this issue when homedir was exported via nfs.

Accordingly, use the java tmp dir, passed by the java wrapper code, preferably