### PR TITLE
Package devtools should not be included in PARConnector dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -275,7 +275,7 @@ project(':pa-rconnector') {
         def descFile = file("${rSrc}/NAMESPACE")
         def nl = System.getProperty("line.separator")
         def text = descFile.getText()
-        text = text.concat(nl + "import(rJava, stringr, codetools, devtools, gtools)" + nl)
+        text = text.concat(nl + "import(rJava, stringr, codetools, gtools)" + nl)
         descFile.write(text)
     }
 

--- a/pa-rconnector/src/main/r/DESCRIPTION
+++ b/pa-rconnector/src/main/r/DESCRIPTION
@@ -5,7 +5,7 @@ Title: ProActive R Connector
 Author: The ProActive Team
 Maintainer: The ProActive Team <proactive@ow2.org>
 Description: Parallel execution of R functions and split/merge workflows using ProActive Scheduler
-Depends: R (>= 2.15.0), utils (>= 2.15.0), rJava (>= 0.9), gtools (>= 2.6), codetools (>= 0.2-8), devtools, stringr (>= 0.6.2), methods
+Depends: R (>= 2.15.0), utils (>= 2.15.0), rJava (>= 0.9), gtools (>= 2.6), codetools (>= 0.2-8), stringr (>= 0.6.2), methods
 SystemRequirements: Java (>= 1.7)
 License: AGPL-3
 Collate:


### PR DESCRIPTION
This package was probably added by mistake, it is not required and depends on a lot of native dependencies.