### PR TITLE
#85 Exception when using multiple R scripts inside a Task

### DIFF
--- a/pa-jri/src/main/java/org/ow2/pajri/PAJRIEngine.java
+++ b/pa-jri/src/main/java/org/ow2/pajri/PAJRIEngine.java
@@ -51,10 +51,14 @@ public class PAJRIEngine extends PAREngine implements REngineCallbacks, REngineO
      * @return the singleton instance of the engine
      */
     public static synchronized PAJRIEngine create(PAJRIFactory factory) {
-        if (isInForkedTask()) {
+        if (instance == null) {
             instance = createScriptEngine(factory);
-        } else if (instance == null) {
-            instance = createScriptEngine(factory);
+            Runtime.getRuntime().addShutdownHook(new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    instance.engine.end();
+                }
+            }));
         }
 
         return instance;
@@ -150,10 +154,6 @@ public class PAJRIEngine extends PAREngine implements REngineCallbacks, REngineO
 
             // Fix for PRC-30: Always change working dir to avoid keeping a file handle on task temp dir
             engine.engineEval("setwd(\"" + toRpath(tmpDir) + "\")", ctx);
-            if (isInForkedTask()) {
-                engine.end();
-            }
-
         }
     }
 

--- a/pa-rengine-common/src/test/java/testabstract/TestResultMultipleCalls.java
+++ b/pa-rengine-common/src/test/java/testabstract/TestResultMultipleCalls.java
@@ -1,0 +1,49 @@
+package testabstract;
+
+import org.apache.log4j.BasicConfigurator;
+import org.ow2.proactive.scripting.ScriptResult;
+import org.ow2.proactive.scripting.SimpleScript;
+import org.ow2.proactive.scripting.TaskScript;
+
+import java.io.Serializable;
+
+/**
+ * Test that the result variable, set from a first script evaluation, is available in a second script evalutation.
+ *
+ * @author Activeeon Team
+ */
+public class TestResultMultipleCalls {
+
+    public void test(String engineName) throws Exception {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+        String rScript = "rm(list = ls()); result=FALSE";
+
+        SimpleScript ss = new SimpleScript(rScript, engineName);
+        TaskScript taskScript = new TaskScript(ss);
+        ScriptResult<Serializable> res = taskScript.execute();
+
+        System.out.println("Script output:");
+        System.out.println(res.getOutput());
+
+        org.junit.Assert
+                .assertEquals(
+                        "The result variable declared explicitely in the script is not used as the result of the script by the engine",
+                        Boolean.FALSE, (Boolean) res.getResult());
+
+        rScript = "rm(list = ls());";
+
+        ss = new SimpleScript(rScript, engineName);
+        taskScript = new TaskScript(ss);
+        res = taskScript.execute();
+
+        System.out.println("Script output:");
+        System.out.println(res.getOutput());
+
+        org.junit.Assert
+                .assertEquals(
+                        "The result variable from the previous script evaluation should be reused",
+                        Boolean.FALSE, (Boolean) res.getResult());
+
+    }
+}


### PR DESCRIPTION
Changed the JRI script engine loading and closing mechanism:
- the script engine is a singleton instance.
- the engine is not closed at the end of a script evaluation
- the engine is closed inside a shutdownhook.

This way, in case of a forked task, the engine will be closed before the JVM is terminated, allowing the JVM to shutdown properly.

In cas of a non-forked task, the engine will remain open across all tasks execution and will be closed on node shutdown.

The RServe behavior was not changed for now, as the engine lifecycle is much more complex.