### PR TITLE
Add resultMetadata binding to R engine

### DIFF
--- a/pa-jri/src/test/java/org/ow2/pajri/tests/TestResultMetadata.java
+++ b/pa-jri/src/test/java/org/ow2/pajri/tests/TestResultMetadata.java
@@ -40,7 +40,12 @@ import org.ow2.pajri.PAJRIFactory;
 public class TestResultMetadata extends testabstract.TestResultMetadata {
 
     @Test
-    public void test() throws Exception {
-        super.test(PAJRIFactory.ENGINE_NAME);
+    public void testMetadata() throws Exception {
+        super.testMetadata(PAJRIFactory.ENGINE_NAME);
+    }
+
+    @Test
+    public void testEmptyMetadata() throws Exception {
+        super.testEmptyMetadata(PAJRIFactory.ENGINE_NAME);
     }
 }

--- a/pa-rengine-common/src/main/java/org/ow2/parengine/PAREngine.java
+++ b/pa-rengine-common/src/main/java/org/ow2/parengine/PAREngine.java
@@ -173,9 +173,16 @@ public abstract class PAREngine extends AbstractScriptEngine {
      */
     protected Map<String, String> assignResultMetadata(Bindings bindings, ScriptContext ctx) {
         Map<String, String> metadata = (Map<String, String>) bindings.get(SchedulerConstants.RESULT_METADATA_VARIABLE);
-        if (metadata != null) {
-            engine.engineSet(SchedulerConstants.RESULT_METADATA_VARIABLE, metadata, ctx);
+        if (metadata == null) {
+            return null;
         }
+        // If the map is empty, the R engine will convert it as a NULL object.
+        // we need to add a dummy metadata to avoid this issue.
+        if (metadata.isEmpty()) {
+            metadata.put("r.result", "true");
+        }
+        engine.engineSet(SchedulerConstants.RESULT_METADATA_VARIABLE, metadata, ctx);
+
         return metadata;
     }
 

--- a/pa-rengine-common/src/test/java/testabstract/TestResultMetadata.java
+++ b/pa-rengine-common/src/test/java/testabstract/TestResultMetadata.java
@@ -47,7 +47,30 @@ import java.util.Map;
 
 public class TestResultMetadata {
 
-    public void test(String engineName) throws Exception {
+    public void testEmptyMetadata(String engineName) throws Exception {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+
+        HashMap<String, String> metadata = new HashMap();
+
+        Map<String, Object> aBindings = Collections.singletonMap(SchedulerConstants.RESULT_METADATA_VARIABLE,
+                (Object) metadata);
+
+        String rScript = "resultMetadata[['b']]='valueb'; result = TRUE";
+
+        SimpleScript ss = new SimpleScript(rScript, engineName);
+        TaskScript taskScript = new TaskScript(ss);
+        ScriptResult<Serializable> res = taskScript.execute(aBindings, System.out, System.err);
+        org.junit.Assert
+                .assertEquals(
+                        "The result should be true",
+                        true, res.getResult());
+        org.junit.Assert
+                .assertEquals("The metadata map should contain the metadata defined in the script", "valueb", metadata.get("b"));
+    }
+
+
+    public void testMetadata(String engineName) throws Exception {
         BasicConfigurator.resetConfiguration();
         BasicConfigurator.configure();
 
@@ -56,6 +79,7 @@ public class TestResultMetadata {
 
         Map<String, Object> aBindings = Collections.singletonMap(SchedulerConstants.RESULT_METADATA_VARIABLE,
                 (Object) metadata);
+
 
         String rScript = "resultMetadata[['b']]='valueb'; result = resultMetadata[['a']]";
 

--- a/pa-rserve/src/test/java/org/ow2/parserve/tests/TestResultMetadata.java
+++ b/pa-rserve/src/test/java/org/ow2/parserve/tests/TestResultMetadata.java
@@ -39,7 +39,12 @@ import org.ow2.parserve.PARServeFactory;
 
 public class TestResultMetadata extends testabstract.TestResultMetadata {
     @Test
-    public void test() throws Exception {
-        super.test(PARServeFactory.ENGINE_NAME);
+    public void testEmptyMetadata() throws Exception {
+        super.testEmptyMetadata(PARServeFactory.ENGINE_NAME);
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        super.testMetadata(PARServeFactory.ENGINE_NAME);
     }
 }


### PR DESCRIPTION
- when the metadata map is empty (which is always the case), the R engine converts it into a NULL object, which creates a java NPE when retrieving back the metadata. Add a dummy entry into the metadata map to avoid this problem

- added a test which checks that an empty metadata map is correctly handled.