### PR TITLE
Set the LC_NUMERIC locale to C by default

### DIFF
--- a/pa-jri/src/test/java/org/ow2/pajri/tests/TestLocale.java
+++ b/pa-jri/src/test/java/org/ow2/pajri/tests/TestLocale.java
@@ -1,0 +1,38 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.pajri.tests;
+
+import org.junit.Test;
+import org.ow2.pajri.PAJRIFactory;
+
+
+public class TestLocale extends testabstract.TestLocale {
+
+    @Test
+    public void test() throws Exception {
+        super.test(PAJRIFactory.ENGINE_NAME);
+    }
+}

--- a/pa-rengine-common/src/main/java/org/ow2/parengine/PAREngine.java
+++ b/pa-rengine-common/src/main/java/org/ow2/parengine/PAREngine.java
@@ -318,8 +318,13 @@ public abstract class PAREngine extends AbstractScriptEngine {
                           ERROR_TAG_END + "', sep='\\n') })", ctx);
     }
 
+    protected void setNumericLocale(ScriptContext ctx) {
+        engine.engineEval("Sys.setlocale(category = 'LC_NUMERIC', locale = 'C')", ctx);
+    }
+
     protected void prepareExecution(ScriptContext ctx, Bindings bindings) {
         this.enableWarnings(ctx);
+        this.setNumericLocale(ctx);
         this.customizeErrors(ctx);
         this.assignArguments(bindings, ctx);
         this.assignProgress(bindings, ctx);

--- a/pa-rengine-common/src/test/java/testabstract/TestLocale.java
+++ b/pa-rengine-common/src/test/java/testabstract/TestLocale.java
@@ -1,0 +1,55 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package testabstract;
+
+import java.io.Serializable;
+
+import org.apache.log4j.BasicConfigurator;
+import org.ow2.proactive.scripting.ScriptResult;
+import org.ow2.proactive.scripting.SimpleScript;
+import org.ow2.proactive.scripting.TaskScript;
+
+
+public class TestLocale {
+
+    public void test(String engineName) throws Exception {
+        BasicConfigurator.resetConfiguration();
+        BasicConfigurator.configure();
+
+        String rScript = "result = Sys.getlocale('LC_NUMERIC')";
+
+        SimpleScript ss = new SimpleScript(rScript, engineName);
+        TaskScript taskScript = new TaskScript(ss);
+        ScriptResult<Serializable> res = taskScript.execute();
+
+        System.out.println("Script output:");
+        System.out.println(res.getOutput());
+
+        org.junit.Assert.assertEquals("The result should always return the 'C' value for LC_NUMERIC locale",
+                                      "C",
+                                      res.getResult());
+    }
+}

--- a/pa-rserve/src/test/java/org/ow2/parserve/tests/TestLocale.java
+++ b/pa-rserve/src/test/java/org/ow2/parserve/tests/TestLocale.java
@@ -1,0 +1,37 @@
+/*
+ * ProActive Parallel Suite(TM):
+ * The Open Source library for parallel and distributed
+ * Workflows & Scheduling, Orchestration, Cloud Automation
+ * and Big Data Analysis on Enterprise Grids & Clouds.
+ *
+ * Copyright (c) 2007 - 2017 ActiveEon
+ * Contact: contact@activeeon.com
+ *
+ * This library is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation: version 3 of
+ * the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * If needed, contact us to obtain a release under GPL Version 2 or 3
+ * or a different license than the AGPL.
+ */
+package org.ow2.parserve.tests;
+
+import org.junit.Test;
+import org.ow2.parserve.PARServeFactory;
+
+
+public class TestLocale extends testabstract.TestLocale {
+    @Test
+    public void test() throws Exception {
+        super.test(PARServeFactory.ENGINE_NAME);
+    }
+}


### PR DESCRIPTION
 - R language does not function properly if this locale is different.
 - JRI engine, when it sees a LANG environment variable will affect its value to all locales, thus overwriting LC_NUMERIC. This is especially true on linux systems (on windows LANG env variable is not taken into account)
 - The only workaround found is to automatically set the LC_NUMERIC locale at each R engine execution.